### PR TITLE
Add codemod-add-import-extensions to TypeScript section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) before contributing.
 - [flowshift](https://github.com/albertywu/flowshift) - Flow to typescript codemods.
 - [ts-codemod-scripts](https://github.com/buildo/ts-codemod-scripts) - Collection of basic JS/React codemod scripts to prepare for TS on a codebase.
 - [type-import-codemod](https://github.com/IanVS/type-import-codemod) - Combine type and value imports using Typescript 4.5 type modifier syntax.
+- [codemod-add-import-extensions](https://github.com/TrevorBurnham/codemod-add-import-extensions) - Add file extensions to imports to improve build performance and allow TypeScript code to be executed without compilation.
 
 ## Ruby
 - [Ruby AST Explorer](https://github.com/rajasegar/ruby-ast-explorer) - AST Explorer for Ruby.


### PR DESCRIPTION
I recently created [codemod-add-import-extensions](https://github.com/TrevorBurnham/codemod-add-import-extensions), a codemod for adding file extensions to imports in TypeScript code.

For context, the main motivation for this was to allow TypeScript code to be run directly with its `--experimental-strip-types` feature. [Path rewriting in TypeScript 5.7](https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/#path-rewriting-for-relative-paths) allows imports with a `.ts` extension to be compiled correctly, so imports with those extensions are now compatible with compiled code as well, and should improve build times because the import can be resolved more quickly.